### PR TITLE
Apple Silicon HNSW acceleration via Accelerate + Metal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,21 @@ else()
 endif()
 
 # ========================================
+# 3b. Apple Silicon optimization (NEON + Accelerate)
+# ========================================
+
+if(APPLE AND _ANN_TARGET_ARM64)
+    find_library(ACCELERATE_FW Accelerate)
+    if(ACCELERATE_FW)
+        set(HAVE_ACCELERATE ON)
+        message(STATUS "Apple Accelerate: FOUND")
+    else()
+        set(HAVE_ACCELERATE OFF)
+        message(STATUS "Apple Accelerate: NOT FOUND")
+    endif()
+endif()
+
+# ========================================
 # 4. C++ Extension sources
 # ========================================
 
@@ -201,6 +216,7 @@ list(APPEND EXTENSION_SOURCES
     src/faiss_vector_utils.cpp
     src/gpu_backend_cpu.cpp
     src/metal_diskann_stub.cpp
+    src/hnsw_metal_search.cpp
 )
 
 # Metal GPU backend (Objective-C++)
@@ -299,6 +315,19 @@ if(FAISS_METAL_AVAILABLE)
             -iframework ${REAL_MACOS_SDK}/System/Library/Frameworks)
         target_compile_options(${LOADABLE_EXTENSION_NAME} PRIVATE
             -iframework ${REAL_MACOS_SDK}/System/Library/Frameworks)
+    endif()
+endif()
+
+# Apple Silicon: -mcpu=apple-m1 + Accelerate framework
+if(APPLE AND _ANN_TARGET_ARM64)
+    target_compile_options(${EXTENSION_NAME} PRIVATE -mcpu=apple-m1)
+    target_compile_options(${LOADABLE_EXTENSION_NAME} PRIVATE -mcpu=apple-m1)
+
+    if(HAVE_ACCELERATE)
+        target_link_libraries(${EXTENSION_NAME} ${ACCELERATE_FW})
+        target_link_libraries(${LOADABLE_EXTENSION_NAME} ${ACCELERATE_FW})
+        target_compile_definitions(${EXTENSION_NAME} PRIVATE HAVE_ACCELERATE=1)
+        target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE HAVE_ACCELERATE=1)
     endif()
 endif()
 

--- a/bench/hnsw_apple_silicon.sql
+++ b/bench/hnsw_apple_silicon.sql
@@ -1,0 +1,103 @@
+-- HNSW Apple Silicon benchmark
+-- Tests FAISS HNSW create + search with Accelerate/Metal optimizations
+-- Run from build/release: ./duckdb -f ../../bench/hnsw_apple_silicon.sql
+
+.timer on
+
+-- ========================================
+-- Setup: 10K vectors, 768-dim
+-- ========================================
+
+CREATE TABLE bench_10k (id INT, embedding FLOAT[768]);
+
+INSERT INTO bench_10k
+SELECT i, list_transform(generate_series(1, 768), x -> (random() - 0.5)::FLOAT)::FLOAT[768]
+FROM generate_series(1, 10000) t(i);
+
+-- Use first vector as query
+SET VARIABLE q_768 = (SELECT embedding FROM bench_10k LIMIT 1);
+
+SELECT '--- 10K vectors, 768-dim ---' AS benchmark;
+
+SELECT 'HNSW create (10K)' AS step;
+CREATE INDEX bench_10k_hnsw ON bench_10k USING FAISS (embedding) WITH (type='HNSW', hnsw_m=32);
+
+SELECT 'HNSW search k=10 (10K)' AS step;
+SELECT row_id, distance FROM faiss_index_scan('bench_10k', 'bench_10k_hnsw', getvariable('q_768'), 10);
+
+SELECT 'HNSW search k=100 (10K)' AS step;
+SELECT count(*) FROM faiss_index_scan('bench_10k', 'bench_10k_hnsw', getvariable('q_768'), 100);
+
+DROP INDEX bench_10k_hnsw;
+DROP TABLE bench_10k;
+
+-- ========================================
+-- Setup: 50K vectors, 768-dim
+-- ========================================
+
+CREATE TABLE bench_50k (id INT, embedding FLOAT[768]);
+
+INSERT INTO bench_50k
+SELECT i, list_transform(generate_series(1, 768), x -> (random() - 0.5)::FLOAT)::FLOAT[768]
+FROM generate_series(1, 50000) t(i);
+
+SET VARIABLE q_768 = (SELECT embedding FROM bench_50k LIMIT 1);
+
+SELECT '--- 50K vectors, 768-dim ---' AS benchmark;
+
+SELECT 'HNSW create (50K)' AS step;
+CREATE INDEX bench_50k_hnsw ON bench_50k USING FAISS (embedding) WITH (type='HNSW', hnsw_m=32);
+
+SELECT 'HNSW search k=10 (50K)' AS step;
+SELECT row_id, distance FROM faiss_index_scan('bench_50k', 'bench_50k_hnsw', getvariable('q_768'), 10);
+
+SELECT 'HNSW search k=100 (50K)' AS step;
+SELECT count(*) FROM faiss_index_scan('bench_50k', 'bench_50k_hnsw', getvariable('q_768'), 100);
+
+DROP INDEX bench_50k_hnsw;
+DROP TABLE bench_50k;
+
+-- ========================================
+-- Setup: 100K vectors, 768-dim
+-- ========================================
+
+CREATE TABLE bench_100k (id INT, embedding FLOAT[768]);
+
+INSERT INTO bench_100k
+SELECT i, list_transform(generate_series(1, 768), x -> (random() - 0.5)::FLOAT)::FLOAT[768]
+FROM generate_series(1, 100000) t(i);
+
+SET VARIABLE q_768 = (SELECT embedding FROM bench_100k LIMIT 1);
+
+SELECT '--- 100K vectors, 768-dim ---' AS benchmark;
+
+SELECT 'HNSW create (100K)' AS step;
+CREATE INDEX bench_100k_hnsw ON bench_100k USING FAISS (embedding) WITH (type='HNSW', hnsw_m=32);
+
+SELECT 'HNSW search k=10 (100K)' AS step;
+SELECT row_id, distance FROM faiss_index_scan('bench_100k', 'bench_100k_hnsw', getvariable('q_768'), 10);
+
+SELECT 'HNSW search k=100 (100K)' AS step;
+SELECT count(*) FROM faiss_index_scan('bench_100k', 'bench_100k_hnsw', getvariable('q_768'), 100);
+
+-- ========================================
+-- DiskANN comparison (same 100K data)
+-- ========================================
+
+SELECT '--- DiskANN comparison (100K) ---' AS benchmark;
+
+SELECT 'DiskANN create (100K)' AS step;
+CREATE INDEX bench_100k_diskann ON bench_100k USING DISKANN (embedding);
+
+SELECT 'DiskANN search k=10 (100K)' AS step;
+SELECT row_id, distance FROM diskann_index_scan('bench_100k', 'bench_100k_diskann', getvariable('q_768'), 10);
+
+SELECT 'DiskANN search k=100 (100K)' AS step;
+SELECT count(*) FROM diskann_index_scan('bench_100k', 'bench_100k_diskann', getvariable('q_768'), 100);
+
+-- Cleanup
+DROP INDEX bench_100k_hnsw;
+DROP INDEX bench_100k_diskann;
+DROP TABLE bench_100k;
+
+SELECT 'Benchmark complete' AS status;

--- a/rust_lib/.cargo/config.toml
+++ b/rust_lib/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "target-cpu=apple-m1"]

--- a/src/hnsw_metal_search.cpp
+++ b/src/hnsw_metal_search.cpp
@@ -1,0 +1,252 @@
+#ifdef FAISS_AVAILABLE
+#if defined(FAISS_METAL_ENABLED) || defined(HAVE_ACCELERATE)
+
+#include "hnsw_metal_search.hpp"
+#include "metal_diskann_bridge.h"
+
+// DuckDB redefines make_unique — include FAISS headers via wrapper
+#include "faiss_wrapper.hpp"
+#include <faiss/IndexHNSW.h>
+
+#include <algorithm>
+#include <cstring>
+#include <queue>
+#include <unordered_set>
+#include <vector>
+
+#ifdef HAVE_ACCELERATE
+#include <vecLib/vDSP.h>
+#endif
+
+namespace duckdb {
+
+/// GPU threshold — same as ann_search.cpp
+static constexpr size_t MIN_GPU_WORK = 49152;
+
+/// Compute batch distances: Metal GPU if large enough, else Accelerate/scalar CPU.
+static void BatchDistances(const float *query, const float *candidates, int n, int dim, int metric, float *out) {
+	auto work = static_cast<size_t>(n) * dim;
+
+	// Try Metal GPU for large batches
+	if (work >= MIN_GPU_WORK) {
+		int rc = diskann_metal_batch_distances(query, candidates, n, dim, metric, out);
+		if (rc == 0) {
+			return;
+		}
+	}
+
+#ifdef HAVE_ACCELERATE
+	if (metric == 0) { // L2
+		for (int i = 0; i < n; i++) {
+			vDSP_distancesq(query, 1, candidates + i * dim, 1, &out[i], static_cast<vDSP_Length>(dim));
+		}
+	} else { // IP
+		for (int i = 0; i < n; i++) {
+			float dot;
+			vDSP_dotpr(query, 1, candidates + i * dim, 1, &dot, static_cast<vDSP_Length>(dim));
+			out[i] = -dot;
+		}
+	}
+#else
+	for (int i = 0; i < n; i++) {
+		const float *cand = candidates + i * dim;
+		float sum = 0;
+		if (metric == 0) {
+			for (int j = 0; j < dim; j++) {
+				float d = query[j] - cand[j];
+				sum += d * d;
+			}
+		} else {
+			for (int j = 0; j < dim; j++) {
+				sum += query[j] * cand[j];
+			}
+			sum = -sum;
+		}
+		out[i] = sum;
+	}
+#endif
+}
+
+/// Candidate entry for the search priority queues.
+struct Candidate {
+	float distance;
+	int64_t id;
+
+	bool operator>(const Candidate &o) const {
+		return distance > o.distance;
+	}
+	bool operator<(const Candidate &o) const {
+		return distance < o.distance;
+	}
+};
+
+std::vector<std::pair<int64_t, float>> HnswMetalSearch(faiss::Index *index, const float *query, int32_t dimension,
+                                                       int32_t k, int32_t ef_search,
+                                                       const std::unordered_set<int64_t> &deleted_labels) {
+
+	auto *hnsw_index = dynamic_cast<faiss::IndexHNSWFlat *>(index);
+	if (!hnsw_index) {
+		return {};
+	}
+
+	auto &hnsw = hnsw_index->hnsw;
+	auto *storage = hnsw_index->storage;
+
+	if (hnsw.entry_point < 0 || !storage || storage->ntotal == 0) {
+		return {};
+	}
+
+	int metric = (index->metric_type == faiss::METRIC_INNER_PRODUCT) ? 1 : 0;
+	int ef = (ef_search > 0) ? ef_search : hnsw.efSearch;
+	if (ef < k) {
+		ef = k;
+	}
+
+	std::unordered_set<int64_t> visited;
+	visited.reserve(ef * 4);
+
+	// Reconstruct entry point vector and compute initial distance
+	std::vector<float> ep_vec(dimension);
+	storage->reconstruct(hnsw.entry_point, ep_vec.data());
+
+	float ep_dist;
+	BatchDistances(query, ep_vec.data(), 1, dimension, metric, &ep_dist);
+
+	int64_t ep = hnsw.entry_point;
+	float ep_distance = ep_dist;
+
+	// ---- Upper levels (greedy walk): levels max_level down to 1 ----
+	for (int level = hnsw.max_level; level >= 1; level--) {
+		bool changed = true;
+		while (changed) {
+			changed = false;
+
+			size_t begin, end;
+			hnsw.neighbor_range(ep, level, &begin, &end);
+
+			// Collect valid neighbor IDs
+			std::vector<int64_t> neighbor_ids;
+			for (size_t j = begin; j < end; j++) {
+				auto neighbor = hnsw.neighbors[j];
+				if (neighbor < 0) {
+					break;
+				}
+				neighbor_ids.push_back(neighbor);
+			}
+
+			if (neighbor_ids.empty()) {
+				continue;
+			}
+
+			// Batch reconstruct
+			std::vector<float> neighbor_vecs(neighbor_ids.size() * dimension);
+			for (size_t i = 0; i < neighbor_ids.size(); i++) {
+				storage->reconstruct(neighbor_ids[i], neighbor_vecs.data() + i * dimension);
+			}
+
+			// Batch distance computation
+			std::vector<float> dists(neighbor_ids.size());
+			BatchDistances(query, neighbor_vecs.data(), static_cast<int>(neighbor_ids.size()), dimension, metric,
+			               dists.data());
+
+			for (size_t i = 0; i < neighbor_ids.size(); i++) {
+				if (dists[i] < ep_distance) {
+					ep = neighbor_ids[i];
+					ep_distance = dists[i];
+					changed = true;
+				}
+			}
+		}
+	}
+
+	// ---- Level 0: beam search with ef candidates ----
+	// Min-heap: candidates to explore (nearest first)
+	std::priority_queue<Candidate, std::vector<Candidate>, std::greater<Candidate>> candidates;
+	// Max-heap: top results (farthest first, so we can prune)
+	std::priority_queue<Candidate> results;
+
+	candidates.push({ep_distance, ep});
+	results.push({ep_distance, ep});
+	visited.insert(ep);
+
+	while (!candidates.empty()) {
+		auto current = candidates.top();
+		candidates.pop();
+
+		// If current candidate is farther than our worst result, we're done
+		if (current.distance > results.top().distance && static_cast<int>(results.size()) >= ef) {
+			break;
+		}
+
+		// Get level-0 neighbors
+		size_t begin, end;
+		hnsw.neighbor_range(current.id, 0, &begin, &end);
+
+		// Collect unvisited neighbor IDs
+		std::vector<int64_t> unvisited;
+		for (size_t j = begin; j < end; j++) {
+			auto neighbor = hnsw.neighbors[j];
+			if (neighbor < 0) {
+				break;
+			}
+			if (visited.count(neighbor) == 0) {
+				visited.insert(neighbor);
+				unvisited.push_back(neighbor);
+			}
+		}
+
+		if (unvisited.empty()) {
+			continue;
+		}
+
+		// Batch reconstruct neighbor vectors
+		std::vector<float> neighbor_vecs(unvisited.size() * dimension);
+		for (size_t i = 0; i < unvisited.size(); i++) {
+			storage->reconstruct(unvisited[i], neighbor_vecs.data() + i * dimension);
+		}
+
+		// Batch distance computation (the hot path — Metal or Accelerate)
+		std::vector<float> dists(unvisited.size());
+		BatchDistances(query, neighbor_vecs.data(), static_cast<int>(unvisited.size()), dimension, metric,
+		               dists.data());
+
+		for (size_t i = 0; i < unvisited.size(); i++) {
+			float d = dists[i];
+			if (static_cast<int>(results.size()) < ef || d < results.top().distance) {
+				candidates.push({d, unvisited[i]});
+				results.push({d, unvisited[i]});
+				if (static_cast<int>(results.size()) > ef) {
+					results.pop(); // evict farthest
+				}
+			}
+		}
+	}
+
+	// Extract results from max-heap, filter deleted, take top k
+	std::vector<std::pair<int64_t, float>> output;
+	output.reserve(results.size());
+	while (!results.empty()) {
+		auto &top = results.top();
+		if (deleted_labels.count(top.id) == 0) {
+			output.emplace_back(top.id, top.distance);
+		}
+		results.pop();
+	}
+
+	// Sort by distance ascending (heap gave us descending order)
+	std::sort(output.begin(), output.end(), [](const std::pair<int64_t, float> &a, const std::pair<int64_t, float> &b) {
+		return a.second < b.second;
+	});
+
+	// Trim to k
+	if (static_cast<int>(output.size()) > k) {
+		output.resize(k);
+	}
+
+	return output;
+}
+
+} // namespace duckdb
+
+#endif // FAISS_METAL_ENABLED || HAVE_ACCELERATE
+#endif // FAISS_AVAILABLE

--- a/src/include/hnsw_metal_search.hpp
+++ b/src/include/hnsw_metal_search.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifdef FAISS_AVAILABLE
+#if defined(FAISS_METAL_ENABLED) || defined(HAVE_ACCELERATE)
+
+#include <faiss/Index.h>
+#include <cstdint>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace duckdb {
+
+/// Metal/Accelerate-accelerated HNSW search using batch distance dispatch.
+/// Traverses the HNSW graph via FAISS public API, batches neighbor vectors,
+/// and dispatches distance computation to Metal GPU or Accelerate vDSP.
+///
+/// Returns up to k (label, distance) pairs sorted by distance.
+std::vector<std::pair<int64_t, float>> HnswMetalSearch(faiss::Index *index, // Must be IndexHNSWFlat
+                                                       const float *query, int32_t dimension, int32_t k,
+                                                       int32_t ef_search, // 0 = use index default
+                                                       const std::unordered_set<int64_t> &deleted_labels);
+
+} // namespace duckdb
+
+#endif // FAISS_METAL_ENABLED || HAVE_ACCELERATE
+#endif // FAISS_AVAILABLE


### PR DESCRIPTION
## Summary

- Add `-mcpu=apple-m1` compile flags for extension C++ and Rust targets
- Replace scalar distance loop with Apple Accelerate `vDSP_distancesq`/`vDSP_dotpr` (AMX coprocessor)
- Custom HNSW graph traversal (`HnswMetalSearch`) that batches neighbor vector reconstruction and dispatches distance computation to Metal GPU (large batches) or Accelerate vDSP (small batches)
- Route HNSW search through accelerated path in `FaissIndex::Search` when `FAISS_METAL_ENABLED` or `HAVE_ACCELERATE`
- Fix Rust `insert_batch` -> sequential `insert` calls (upstream API removed the method)
- Add HNSW benchmark script (`bench/hnsw_apple_silicon.sql`)

### Benchmark (100K vectors, 768-dim, Apple Silicon)

| Operation | HNSW | DiskANN |
|-----------|------|---------|
| Index create | 65s | 405s |
| Search k=10 | ~3ms | ~5ms |
| Search k=100 | ~4ms | ~3ms |

## Test plan

- [x] All 23 unit tests pass (705 assertions)
- [x] FAISS basic/GPU/persist/optimizer/IVFFlat/bind tests pass
- [x] DiskANN tests pass (Rust insert fix)
- [x] Benchmark runs end-to-end at 10K/50K/100K scales
- [ ] Verify on CI (non-Apple platforms should compile fine — all changes are gated behind `APPLE AND _ANN_TARGET_ARM64` / `HAVE_ACCELERATE` / `FAISS_METAL_ENABLED`)